### PR TITLE
incorrect celery import into base settings

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -161,6 +161,7 @@ Listed in alphabetical order.
   Travis McNeill           `@Travistock`_               @tavistock_esq
   Vitaly Babiy
   Vivian Guillen           `@viviangb`_
+  Wee Liat                 `@weeliat`_
   Will Farley              `@goldhand`_                 @g01dhand
   William Archinal         `@archinal`_
   Yaroslav Halchenko
@@ -271,6 +272,7 @@ Listed in alphabetical order.
 .. _@afrowave: https://github.com/afrowave
 .. _@pchiquet: https://github.com/pchiquet
 .. _@delneg: https://github.com/delneg
+.. _@weeliat: https://github.com/weeliat
 Special Thanks
 ~~~~~~~~~~~~~~
 

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -273,7 +273,6 @@ LOGIN_URL = 'account_login'
 AUTOSLUG_SLUGIFY_FUNCTION = 'slugify.slugify'
 {% if cookiecutter.use_celery == 'y' %}
 ########## CELERY
-INSTALLED_APPS += ['{{cookiecutter.project_slug}}.taskapp.celery.CeleryConfig']
 CELERY_BROKER_URL = env('CELERY_BROKER_URL', default='django://')
 if CELERY_BROKER_URL == 'django://':
     CELERY_RESULT_BACKEND = 'redis://'


### PR DESCRIPTION
## Description
`ModuleNotFoundError: No module named '{{cookiecutter.project_slug}}.taskapp.celery.CeleryConfig'; '{{cookiecutter.project_slug}}.taskapp.celery' is not a package`
will show up when this cookiecutter template is used with **Celery** chosen as **Y**

This PR fixes the issue and allow the initial tests to pass.